### PR TITLE
fix: update Rust to install Debian package instead

### DIFF
--- a/modules/40-rust.yml
+++ b/modules/40-rust.yml
@@ -1,4 +1,5 @@
 name: rust
-type: shell
-commands:
-- curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+type: apt
+source:
+  packages:
+  - rust-all


### PR DESCRIPTION
As mentioned by @axtloss in Discord, the `rust` commands aren't found in the image as by default they seem to be installed in the root partition of the user. So this PR reverts to using the `rust-all` Debian package.