### PR TITLE
feat: add dependencies for apx-gui, blueprint-compiler

### DIFF
--- a/modules/100-apx-gui-deps.yml
+++ b/modules/100-apx-gui-deps.yml
@@ -1,0 +1,9 @@
+name: apx-gui-deps
+type: apt
+source:
+  packages:
+  - appstream-util
+  - desktop-file-utils
+  - libgtk-4-bin
+  - libvte-2.91-gtk4-dev
+  - python3-gi

--- a/modules/30-gtk.yml
+++ b/modules/30-gtk.yml
@@ -7,3 +7,4 @@ source:
   - libgnome-desktop-4-dev
   - libgweather-4-dev
   - libjpeg-dev
+  - blueprint-compiler

--- a/recipe.yml
+++ b/recipe.yml
@@ -18,6 +18,7 @@ modules:
     - modules/20-build-tools
     - modules/30-gtk
     - modules/40-rust
+    - modules/100-apx-gui-deps
 
 - name: host-spawn
   type: shell


### PR DESCRIPTION
This PR adds missing dependencies in the dev image for building `apx-gui` inside a container.