### PR TITLE
feat: add itstool as dep for apx-gui

### DIFF
--- a/modules/100-apx-gui-deps.yml
+++ b/modules/100-apx-gui-deps.yml
@@ -7,3 +7,4 @@ source:
   - libgtk-4-bin
   - libvte-2.91-gtk4-dev
   - python3-gi
+  - itstool


### PR DESCRIPTION
Itstool is used for translating XML documents with PO files. (It is required for compiling help pages in meson).

> [!NOTE]
> I am currently working on the help pages, adding this package as it will be required in future.