### PR TITLE
chore: bump Vib action to v0.6.2

### DIFF
--- a/.github/workflows/vib-build.yml
+++ b/.github/workflows/vib-build.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: vanilla-os/vib-gh-action@v0.3.2-2
+    - uses: vanilla-os/vib-gh-action@v0.6.2
 
     - name: Build the Docker image
       run: docker image build -f Containerfile --tag ghcr.io/vanilla-os/dev:main .

--- a/.github/workflows/vib-pr.yml
+++ b/.github/workflows/vib-pr.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: vanilla-os/vib-gh-action@v0.3.2-2
+    - uses: vanilla-os/vib-gh-action@v0.6.2
 
     - name: Build the Docker image
       run: docker image build -f Containerfile --tag dev:validation .

--- a/recipe.yml
+++ b/recipe.yml
@@ -1,40 +1,43 @@
-base: ghcr.io/vanilla-os/pico:main
 name: Vanilla Dev
-singlelayer: false
-labels:
-  maintainer: Vanilla OS Contributors
-args:
-  DEBIAN_FRONTEND: noninteractive
-runs:
-- echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/01norecommends
+id: vanilla-dev
+stages:
+- id: build
+  base: ghcr.io/vanilla-os/pico:main
+  singlelayer: false
+  labels:
+    maintainer: Vanilla OS Contributors
+  args:
+    DEBIAN_FRONTEND: noninteractive
+  runs:
+  - echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/01norecommends
 
-modules:
-- name: packages-modules
-  type: includes
-  includes:
-    - modules/00-basics
-    - modules/01-vanilla-base-files
-    - modules/05-go
-    - modules/10-python
-    - modules/20-build-tools
-    - modules/30-gtk
-    - modules/40-rust
-    - modules/100-apx-gui-deps
+  modules:
+  - name: packages-modules
+    type: includes
+    includes:
+      - modules/00-basics.yml
+      - modules/01-vanilla-base-files.yml
+      - modules/05-go.yml
+      - modules/10-python.yml
+      - modules/20-build-tools.yml
+      - modules/30-gtk.yml
+      - modules/40-rust.yml
+      - modules/100-apx-gui-deps.yml
 
-- name: host-spawn
-  type: shell
-  commands:
-    - wget https://github.com/1player/host-spawn/releases/download/1.5.0/host-spawn-x86_64
-    - mv host-spawn-x86_64 /usr/bin/host-spawn
-    - chmod +x /usr/bin/host-spawn
+  - name: host-spawn
+    type: shell
+    commands:
+      - wget https://github.com/1player/host-spawn/releases/download/1.5.0/host-spawn-x86_64
+      - mv host-spawn-x86_64 /usr/bin/host-spawn
+      - chmod +x /usr/bin/host-spawn
 
-- name: cleanup
-  type: shell
-  commands:
-  - apt autoremove -y
-  - apt clean
-  - rm -rf /var/cache/*
-  - rm -rf /tmp/*
-  - rm -rf /var/tmp/*
-  - rm -rf /sources
-  - mkdir -p /var/cache/apt/archives/partial
+  - name: cleanup
+    type: shell
+    commands:
+    - apt autoremove -y
+    - apt clean
+    - rm -rf /var/cache/*
+    - rm -rf /tmp/*
+    - rm -rf /var/tmp/*
+    - rm -rf /sources
+    - mkdir -p /var/cache/apt/archives/partial


### PR DESCRIPTION
## Changes

- Bump Vib action to `v0.6.2`.
- Update `recipe.yml` to the new syntax.