### PR TITLE
chore/deps: bump host-spawn to 1.6.0

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -27,7 +27,7 @@ stages:
   - name: host-spawn
     type: shell
     commands:
-      - wget https://github.com/1player/host-spawn/releases/download/1.5.0/host-spawn-x86_64
+      - wget https://github.com/1player/host-spawn/releases/download/v1.6.0/host-spawn-x86_64
       - mv host-spawn-x86_64 /usr/bin/host-spawn
       - chmod +x /usr/bin/host-spawn
 


### PR DESCRIPTION
**Changelog**: https://github.com/1player/host-spawn/releases/tag/v1.6.0

This release mainly adds a cool new flag `-cwd` allowing us to specify a working directory for the spawned process i.e `host-spawn -cwd /home/user ls` will list files from the `/home` directory.